### PR TITLE
Updated contract address

### DIFF
--- a/build/subgraph.yaml
+++ b/build/subgraph.yaml
@@ -6,7 +6,7 @@ dataSources:
     name: Poster
     network: localhost
     source:
-      address: "0x000000000000cd17345801aa8147b8D3950260FF"
+      address: "0x000000000000cd17345801aa8147b8d3950260ff"
       startBlock: 1
       abi: Poster
     mapping:

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -6,7 +6,7 @@ dataSources:
     name: Poster
     network: {{network}}
     source:
-      address: "0x000000000000cd17345801aa8147b8D3950260FF"
+      address: "0x000000000000cd17345801aa8147b8d3950260ff"
       startBlock: {{startBlock}}
       abi: Poster
     mapping:


### PR DESCRIPTION
For some reason, only this non-checksummed address was picked up locally. We'll try and see if the `hosted-service` still picks events up.